### PR TITLE
Use an UUID instead of Random.nextInt(1000) when creating a temporary filename

### DIFF
--- a/src/main/scala/com/springml/spark/sftp/DefaultSource.scala
+++ b/src/main/scala/com/springml/spark/sftp/DefaultSource.scala
@@ -16,6 +16,7 @@
 package com.springml.spark.sftp
 
 import java.io.File
+import java.util.UUID
 
 import com.springml.sftp.client.SFTPClient
 import org.apache.commons.io.FilenameUtils
@@ -119,7 +120,6 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
     upload(tempFile, path, sftpClient)
     return createReturnRelation(data)
   }
-
   private def copyToHdfs(sqlContext: SQLContext, fileLocation : String,
                          hdfsTemp : String): String  = {
     val hadoopConf = sqlContext.sparkContext.hadoopConfiguration
@@ -223,8 +223,7 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
   private def writeToTemp(sqlContext: SQLContext, df: DataFrame,
                           hdfsTemp: String, tempFolder: String, fileType: String, header: String,
                           delimiter: String) : String = {
-    val r = scala.util.Random
-    val randomSuffix = "spark_sftp_connection_temp" + r.nextInt(1000)
+    val randomSuffix = "spark_sftp_connection_temp_" + UUID.randomUUID
     val hdfsTempLocation = hdfsTemp + File.separator + randomSuffix
     val localTempLocation = tempFolder + File.separator + randomSuffix
 


### PR DESCRIPTION
We use this library to create many files, and sometimes it throws an exception saying the file already exists; because this library creates a temporary file and the random suffix it assigns does not have enough range.  

This PR makes it use `java.util.UUID.randomUUID` which makes having collisions practically impossible, at the cost of a slightly unpleasant filenames, but I think it is a good trade off.