### PR TITLE
Add support for read/write xml files #36

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ df.write.
       option("codec", "bzip2").
       save("/ftp/files/sample.csv")
 
+
 // Construct spark dataframe using text file in FTP server
  val df = spark.read.
             format("com.springml.spark.sftp").
@@ -86,6 +87,25 @@ df.write.
             option("password", "****").
             option("fileType", "txt").
             load("config")
+            
+ // Construct spark dataframe using xml file in FTP server           
+            val df = spark.read.
+                 format("com.springml.spark.sftp").
+                 option("host", "SFTP_HOST").
+                 option("username", "SFTP_USER").
+                 option("password", "*****").
+                 option("fileType", "xml").
+                 option("rowTag", "YEAR").load("myxml.xml")
+                 
+ // Write dataframe as XML file to FTP server           
+           
+                 df.write.format("com.springml.spark.sftp").
+                 option("host", "SFTP_HOST").
+                 option("username", "SFTP_USER").
+                 option("password", "*****").
+                 option("fileType", "xml").
+                 option("rootTag", "YTD").
+                 option("rowTag", "YEAR").save("myxmlOut.xml.gz")
 
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,8 @@ version := "1.1.2"
 // Dependent libraries
 libraryDependencies ++= Seq(
   "com.springml" % "sftp.client" % "1.0.3",
-  "org.mockito" % "mockito-core" % "2.0.31-beta"
+  "org.mockito" % "mockito-core" % "2.0.31-beta",
+  "com.databricks" % "spark-xml_2.11" % "0.4.1"
 )
 
 // used spark components

--- a/src/main/scala/com/springml/spark/sftp/DatasetRelation.scala
+++ b/src/main/scala/com/springml/spark/sftp/DatasetRelation.scala
@@ -16,6 +16,7 @@ case class DatasetRelation(
     inferSchema: String,
     header: String,
     delimiter: String,
+    rowTag: String,
     customSchema: StructType,
     sqlContext: SQLContext) extends BaseRelation with TableScan {
 
@@ -36,6 +37,10 @@ case class DatasetRelation(
         df = dataframeReader.parquet(fileLocation)
       } else if (fileType.equals("txt")) {
         df = dataframeReader.text(fileLocation)
+      } else if (fileType.equals("xml")) {
+        df = dataframeReader.format(constants.xmlClass)
+          .option(constants.xmlRowTag, rowTag)
+          .load(fileLocation)
       }
       else if (fileType.equals("csv")) {
         df = dataframeReader.

--- a/src/main/scala/com/springml/spark/sftp/constants.scala
+++ b/src/main/scala/com/springml/spark/sftp/constants.scala
@@ -1,0 +1,12 @@
+package com.springml.spark.sftp
+
+/**
+  * Created by bagopalan on 9/16/18.
+  */
+object constants {
+
+  val xmlClass: String = "com.databricks.spark.xml"
+  val xmlRowTag: String = "rowTag"
+  val xmlRootTag: String = "rootTag"
+
+}

--- a/src/test/resources/books.xml
+++ b/src/test/resources/books.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0"?>
+<catalog>
+    <book id="bk101">
+        <author>Gambardella, Matthew</author>
+        <title>XML Developer's Guide</title>
+        <genre>Computer</genre>
+        <price>44.95</price>
+        <publish_date>2000-10-01</publish_date>
+        <description>
+
+
+            An in-depth look at creating applications
+            with XML.This manual describes Oracle XML DB, and how you can use it to store, generate, manipulate, manage,
+            and query XML data in the database.
+
+
+            After introducing you to the heart of Oracle XML DB, namely the XMLType framework and Oracle XML DB repository,
+            the manual provides a brief introduction to design criteria to consider when planning your Oracle XML DB
+            application. It provides examples of how and where you can use Oracle XML DB.
+
+
+            The manual then describes ways you can store and retrieve XML data using Oracle XML DB, APIs for manipulating
+            XMLType data, and ways you can view, generate, transform, and search on existing XML data. The remainder of
+            the manual discusses how to use Oracle XML DB repository, including versioning and security,
+            how to access and manipulate repository resources using protocols, SQL, PL/SQL, or Java, and how to manage
+            your Oracle XML DB application using Oracle Enterprise Manager. It also introduces you to XML messaging and
+            Oracle Streams Advanced Queuing XMLType support.
+        </description></book><book id="bk102">
+    <author>Ralls, Kim</author>
+    <title>Midnight Rain</title>
+    <genre>Fantasy</genre>
+    <price>5.95</price>
+    <publish_date>2000-12-16</publish_date>
+    <description>A former architect battles corporate zombies,
+        an evil sorceress, and her own childhood to become queen
+        of the world.</description>
+</book>
+    <book id="bk103">
+        <author>Corets, Eva</author>
+        <title>Maeve Ascendant</title>
+        <genre>Fantasy</genre>
+        <price>5.95</price>
+        <publish_date>2000-11-17</publish_date>
+        <description>After the collapse of a nanotechnology
+            society in England, the young survivors lay the
+            foundation for a new society.</description>
+    </book>
+    <book id="bk104">
+        <author>Corets, Eva</author>
+        <title>Oberon's Legacy</title>
+        <genre>Fantasy</genre>
+        <price>5.95</price>
+        <publish_date>2001-03-10</publish_date>
+        <description>In post-apocalypse England, the mysterious
+            agent known only as Oberon helps to create a new life
+            for the inhabitants of London. Sequel to Maeve
+            Ascendant.</description>
+    </book>
+    <book id="bk105">
+        <author>Corets, Eva</author>
+        <title>The Sundered Grail</title>
+        <genre>Fantasy</genre>
+        <price>5.95</price>
+        <publish_date>2001-09-10</publish_date>
+        <description>The two daughters of Maeve, half-sisters,
+            battle one another for control of England. Sequel to
+            Oberon's Legacy.</description>
+    </book>
+    <book id="bk106">
+        <author>Randall, Cynthia</author>
+        <title>Lover Birds</title>
+        <genre>Romance</genre>
+        <price>4.95</price>
+        <publish_date>2000-09-02</publish_date>
+        <description>When Carla meets Paul at an ornithology
+            conference, tempers fly as feathers get ruffled.</description>
+    </book>
+    <book id="bk107">
+        <author>Thurman, Paula</author>
+        <title>Splish Splash</title>
+        <genre>Romance</genre>
+        <price>4.95</price>
+        <publish_date>2000-11-02</publish_date>
+        <description>A deep sea diver finds true love twenty
+            thousand leagues beneath the sea.</description>
+    </book>
+    <book id="bk108">
+        <author>Knorr, Stefan</author>
+        <title>Creepy Crawlies</title>
+        <genre>Horror</genre>
+        <price>4.95</price>
+        <publish_date>2000-12-06</publish_date>
+        <description>An anthology of horror stories about roaches,
+            centipedes, scorpions  and other insects.</description>
+    </book>
+    <book id="bk109">
+        <author>Kress, Peter</author>
+        <title>Paradox Lost</title>
+        <genre>Science Fiction</genre>
+        <price>6.95</price>
+        <publish_date>2000-11-02</publish_date>
+        <description>After an inadvertant trip through a Heisenberg
+            Uncertainty Device, James Salway discovers the problems
+            of being quantum.</description>
+    </book>
+    <book id="bk110">
+        <author>O'Brien, Tim</author>
+        <title>Microsoft .NET: The Programming Bible</title>
+        <genre>Computer</genre>
+        <price>36.95</price>
+        <publish_date>2000-12-09</publish_date>
+        <description>Microsoft's .NET initiative is explored in
+            detail in this deep programmer's reference.</description>
+    </book>
+    <book id="bk111">
+        <author>O'Brien, Tim</author>
+        <title>MSXML3: A Comprehensive Guide</title>
+        <genre>Computer</genre>
+        <price>36.95</price>
+        <publish_date>2000-12-01</publish_date>
+        <description>The Microsoft MSXML3 parser is covered in
+            detail, with attention to XML DOM interfaces, XSLT processing,
+            SAX and more.</description>
+    </book>
+    <book id="bk112">
+        <author>Galos, Mike</author>
+        <title>Visual Studio 7: A Comprehensive Guide</title>
+        <genre>Computer</genre>
+        <price>49.95</price>
+        <publish_date>2001-04-16</publish_date>
+        <description>Microsoft Visual Studio 7 is explored in depth,
+            looking at how Visual Basic, Visual C++, C#, and ASP+ are
+            integrated into a comprehensive development
+            environment.</description>
+    </book>
+</catalog>

--- a/src/test/scala/com/springml/spark/sftp/CustomSchemaTest.scala
+++ b/src/test/scala/com/springml/spark/sftp/CustomSchemaTest.scala
@@ -43,7 +43,7 @@ class CustomSchemaTest extends FunSuite with BeforeAndAfterEach {
     val expectedSchema = StructType(columnStruct)
 
     val fileLocation = getClass.getResource("/sample.csv").getPath
-    val dsr = DatasetRelation(fileLocation, "csv", "false", "true", ",", expectedSchema, ss.sqlContext)
+    val dsr = DatasetRelation(fileLocation, "csv", "false", "true", ",", null, expectedSchema, ss.sqlContext)
     val rdd = dsr.buildScan()
 
     assert(dsr.schema.fields.length == columnStruct.length)
@@ -55,7 +55,7 @@ class CustomSchemaTest extends FunSuite with BeforeAndAfterEach {
     val expectedSchema = StructType(columnStruct)
 
     val fileLocation = getClass.getResource("/people.json").getPath
-    val dsr = DatasetRelation(fileLocation, "json", "false", "true", ",", expectedSchema, ss.sqlContext)
+    val dsr = DatasetRelation(fileLocation, "json", "false", "true", ",", null, expectedSchema, ss.sqlContext)
     val rdd = dsr.buildScan()
 
     assert(dsr.schema.fields.length == columnStruct.length)

--- a/src/test/scala/com/springml/spark/sftp/TestDatasetRelation.scala
+++ b/src/test/scala/com/springml/spark/sftp/TestDatasetRelation.scala
@@ -15,43 +15,50 @@ class TestDatasetRelation extends FunSuite with BeforeAndAfterEach {
 
   test ("Read CSV") {
     val fileLocation = getClass.getResource("/sample.csv").getPath
-    val dsr = DatasetRelation(fileLocation, "csv", "false", "true", ",", null, ss.sqlContext)
+    val dsr = DatasetRelation(fileLocation, "csv", "false", "true", ",", null, null, ss.sqlContext)
     val rdd = dsr.buildScan()
     assert(3 == rdd.count())
   }
 
   test ("Read CSV using custom delimiter") {
     val fileLocation = getClass.getResource("/sample.csv").getPath
-    val dsr = DatasetRelation(fileLocation, "csv", "false", "true", ";", null, ss.sqlContext)
+    val dsr = DatasetRelation(fileLocation, "csv", "false", "true", ";", null, null, ss.sqlContext)
     val rdd = dsr.buildScan()
     assert(3 == rdd.count())
   }
 
   test ("Read JSON") {
     val fileLocation = getClass.getResource("/people.json").getPath
-    val dsr = DatasetRelation(fileLocation, "json", "false", "true", ",", null, ss.sqlContext)
+    val dsr = DatasetRelation(fileLocation, "json", "false", "true", ",", null, null, ss.sqlContext)
     val rdd = dsr.buildScan()
     assert(3 == rdd.count())
   }
 
   test ("Read AVRO") {
     val fileLocation = getClass.getResource("/users.avro").getPath
-    val dsr = DatasetRelation(fileLocation, "avro", "false", "true", ",", null, ss.sqlContext)
+    val dsr = DatasetRelation(fileLocation, "avro", "false", "true", ",", null, null, ss.sqlContext)
     val rdd = dsr.buildScan()
     assert(2 == rdd.count())
   }
 
   test ("Read parquet") {
     val fileLocation = getClass.getResource("/users.parquet").getPath
-    val dsr = DatasetRelation(fileLocation, "parquet", "false", "true", ",", null, ss.sqlContext)
+    val dsr = DatasetRelation(fileLocation, "parquet", "false", "true", ",", null, null, ss.sqlContext)
     val rdd = dsr.buildScan()
     assert(2 == rdd.count())
   }
 
   test ("Read text file") {
     val fileLocation = getClass.getResource("/plaintext.txt").getPath
-    val dsr = DatasetRelation(fileLocation, "txt", "false", "true", ",", null, ss.sqlContext)
+    val dsr = DatasetRelation(fileLocation, "txt", "false", "true", ",", null, null, ss.sqlContext)
     val rdd = dsr.buildScan()
     assert(3 == rdd.count())
+  }
+
+  test ("Read xml file") {
+    val fileLocation = getClass.getResource("/books.xml").getPath
+    val dsr = DatasetRelation(fileLocation, "xml", "false", "true", ",", "book", null, ss.sqlContext)
+    val rdd = dsr.buildScan()
+    assert(12 == rdd.count())
   }
 }


### PR DESCRIPTION
Overview of the PR:
================

Presently we support txt, avro, parquet, csv, and json.
By this PR, we will have support for xml files too.
https://github.com/databricks/spark-xml => Has support for Spark XML connectivity.

We have used this as a dependency to spark sftp so that we can read/write XML files from SFTP servers.

How the code was tested:
=====================

The code was tested using following statements.

val df = spark.read.
     format("com.springml.spark.sftp").
     option("host", "dropzone.paypalcorp.com").
     option("username", "bagopalan").
     option("password", "Hubgit@345").
     option("fileType", "xml").
     option("rowTag", "YEAR").load("myxml.xml")


     df.write.format("com.springml.spark.sftp").
     option("host", "dropzone.paypalcorp.com").
     option("username", "bagopalan").
     option("password", "Hubgit@345").
     option("fileType", "xml").
     option("rootTag", "YTD").
     option("rowTag", "YEAR").save("myxmlOut.xml.gz")

Out of scope:
===========

Presently we support basic read / write for XML files.
We mainly used the rowTag and rootTag params. 
This is enough for basic read write.
We can enhance it in future with more parameters from spark XML.