### PR TITLE
filter out additional files from temp file location for Databricks

### DIFF
--- a/src/main/scala/com/springml/spark/sftp/DefaultSource.scala
+++ b/src/main/scala/com/springml/spark/sftp/DefaultSource.scala
@@ -270,14 +270,17 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
     Runtime.getRuntime.addShutdownHook(hook)
   }
 
-
   private def copiedFile(tempFileLocation: String) : String = {
     val baseTemp = new File(tempFileLocation)
     val files = baseTemp.listFiles().filter { x =>
       (!x.isDirectory()
         && !x.getName.contains("SUCCESS")
         && !x.isHidden()
-        && !x.getName.contains(".crc"))}
+        && !x.getName.contains(".crc")
+        && !x.getName.contains("_committed_")
+        && !x.getName.contains("_started_")
+        )
+    }
     files(0).getAbsolutePath
   }
 }


### PR DESCRIPTION
In Databricks, whenever write operation triggered it saves committed and started file which is not filtered out in copiedFile function that's why even you give tempLocation explicitly it's not able to pick up a csv file.