### PR TITLE
fix springml#58 Remove the hard dependency to HDFS

### DIFF
--- a/src/main/scala/com/springml/spark/sftp/DefaultSource.scala
+++ b/src/main/scala/com/springml/spark/sftp/DefaultSource.scala
@@ -137,7 +137,7 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
     val hadoopConf = sqlContext.sparkContext.hadoopConfiguration
     val hdfsPath = new Path(fileLocation)
     val fs = hdfsPath.getFileSystem(hadoopConf)
-    if ("hdfs".equalsIgnoreCase(fs.getScheme)) {
+    if (!"file".equalsIgnoreCase(fs.getScheme)) {
       fs.copyFromLocalFile(new Path(fileLocation), new Path(hdfsTemp))
       val filePath = hdfsTemp + "/" + hdfsPath.getName
       fs.deleteOnExit(new Path(filePath))
@@ -152,7 +152,7 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
     val hadoopConf = sqlContext.sparkContext.hadoopConfiguration
     val hdfsPath = new Path(hdfsTemp)
     val fs = hdfsPath.getFileSystem(hadoopConf)
-    if ("hdfs".equalsIgnoreCase(fs.getScheme)) {
+    if (!"file".equalsIgnoreCase(fs.getScheme)) {
       fs.copyToLocalFile(new Path(hdfsTemp), new Path(fileLocation))
       fs.deleteOnExit(new Path(hdfsTemp))
       return fileLocation


### PR DESCRIPTION
Modify the condition to evaluate the case we are NOT on local FS. Doing this way it's wasb(s) or s3 compatible if the cluster is based on this kind of distributed filesystem